### PR TITLE
Change rust version to use binary heap to match go data structure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.idea/

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,35 +1,65 @@
-// Priority Queue 
-use priority_queue::PriorityQueue;
+use std::cmp::Ordering;
+use std::collections::BinaryHeap;
+use std::fmt::Display;
+// Priority Queue
+//use priority_queue::PriorityQueue;
 use std::time::Instant;
 use rand::Rng;
 
+#[derive(Debug, Eq, Ord, Copy, Clone)]
+struct PriorityPair {
+    priority: i64,
+    value: i64,
+}
+
+impl PriorityPair {
+    fn new(value: i64, priority: i64) -> Self {
+        Self {
+            priority,
+            value,
+        }
+    }
+}
+
+impl PartialEq<Self> for PriorityPair {
+    fn eq(&self, other: &Self) -> bool {
+        self.priority == other.priority
+    }
+}
+
+impl PartialOrd<Self> for PriorityPair {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        self.priority.partial_cmp(&other.priority)
+    }
+}
+
 fn main() {
-    let range: i64 = 10000000;
+    let range: i64 = 10_000_000;
     let mut rng = rand::thread_rng();
-    let mut simple_prio = PriorityQueue::new();
+    let mut simple_prio = BinaryHeap::new();
     let mut test_out = String::new();
 
     // Test dequeue order
-    simple_prio.push(1,1);
-    simple_prio.push(2,1);
-    simple_prio.push(3,1);
-    simple_prio.push(4,5);
-    simple_prio.push(5,9);
+    simple_prio.push(PriorityPair::new(1, 1));
+    simple_prio.push(PriorityPair::new(2,1));
+    simple_prio.push(PriorityPair::new(3,1));
+    simple_prio.push(PriorityPair::new(4,5));
+    simple_prio.push(PriorityPair::new(5,9));
 
     while !simple_prio.is_empty() {
-        test_out = [test_out, simple_prio.pop().unwrap_or((0,0)).0.to_string()].join(" ");
+        test_out = [test_out, simple_prio.pop().unwrap_or(PriorityPair::new(0,0)).value.to_string()].join(" ");
     }
 
     println!("Simple Priority Queue Dequeued: {}",test_out);
     
     // Speed Test Enqueue
     let mut pairs: Vec<(i64, i64)> = Vec::new();
-    for n in 1..range {
+    for n in 0..range {
         pairs.push((rng.gen_range(0..range),rng.gen_range(1..9)));
     }
     let start_enqueue = Instant::now();
     for pair in pairs {
-        simple_prio.push(pair.0,pair.1);
+        simple_prio.push(PriorityPair::new(pair.0,pair.1));
     }
     let duration_enqueue = start_enqueue.elapsed();
     println!("Simple Priority Queue Enqueue time: {:?}", duration_enqueue);


### PR DESCRIPTION
I think this is a fair comparison. Unless I messed something up.

```
$ cargo run --release
Simple Priority Queue Dequeued:  5 4 3 2 1
Simple Priority Queue Enqueue time: 161.096478ms
Simple Priority Queue Dequeued Items: 10000000
Simple Priority Queue Dequeue time: 502.921943ms

$ go run priorityQueue.go 
PriorityQueue Enqueued: 1:1, 2:1, 3:1, 4:5, 5:9
PriorityQueue Dequeued: 5:9; 4:5; 1:1; 3:1; 2:1;
PriorityQueue enqueue time: 450.688455ms
PriorityQueue dequeued items: 10000000
PriorityQueue dequeue time: 2.94992849s
```